### PR TITLE
Add font smoothing & disable text sizing in landscape mode

### DIFF
--- a/utils/globalStyle.ts
+++ b/utils/globalStyle.ts
@@ -6,6 +6,10 @@ const GlobalStyle = createGlobalStyle`
   
   body {
     font-family: 'Helvetica', sans-serif;
+
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-text-size-adjust: 100%;
   }
 `
 


### PR DESCRIPTION
Cross-Browser font smoothing
```css
-webkit-font-smoothing: antialiased; /* makes font weights look on the web like in Figma/Sketch files */
-moz-osx-font-smoothing: grayscale;
```

Safari Mobile scales up text in landscape mode by default.
```css
-webkit-text-size-adjust: 100%; /* disable font upscaling in landscape mode */
```